### PR TITLE
Fix panic when SERVER_STARTER_PORT is not defined

### DIFF
--- a/listener/listener.go
+++ b/listener/listener.go
@@ -1,6 +1,7 @@
 package listener
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -11,6 +12,9 @@ import (
 
 const ServerStarterEnvVarName = "SERVER_STARTER_PORT"
 
+var (
+	ErrNoListeningTarget = errors.New("No listening target")
+)
 // Listener is the interface for things that listen on file descriptors
 // specified by Start::Server / server_starter 
 type Listener interface {
@@ -82,6 +86,10 @@ var reLooksLikeHostPort = regexp.MustCompile(`^(\d+):(\d+)$`)
 var reLooksLikePort = regexp.MustCompile(`^\d+$`)
 
 func parseListenTargets(str string) ([]Listener, error) {
+	if str == "" {
+		return nil, ErrNoListeningTarget
+	}
+
 	rawspec := strings.Split(str, ";")
 	ret := make([]Listener, len(rawspec))
 

--- a/listener/listener_test.go
+++ b/listener/listener_test.go
@@ -24,3 +24,16 @@ func TestPort(t *testing.T) {
 		}
 	}
 }
+
+func TestPortNoEnv(t *testing.T) {
+	os.Setenv("SERVER_STARTER_PORT", "")
+
+	ports, err := Ports()
+	if err != ErrNoListeningTarget {
+		t.Error("Ports must return error if no env")
+	}
+
+	if ports != nil {
+		t.Errorf("Ports must return nil if no env")
+	}
+}


### PR DESCRIPTION
I want to run app with Server::Starter and without it in same code.
So I wrote code like below.

``` go
package main

import (
    "fmt"
    "net"
    "net/http"

    "github.com/lestrrat/go-server-starter/listener"
)

func main() {
    listeners, err := listener.ListenAll()
    if err != nil {
        fmt.Println(err)
        return
    }

    var l net.Listener
    if len(listeners) == 0 {
        l, err = net.Listen("tcp", ":8080")
    } else {
        l = listeners[0]
    }

    fmt.Println(http.Serve(l, nil))
}
```

But this code will panic

```
panic: runtime error: index out of range

goroutine 1 [running]:
github.com/lestrrat/go-server-starter/listener.parseListenTargets(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
    /Users/nagata-hiroaki/src/github.com/lestrrat/go-server-starter/listener/listener.go:91 +0x8bd
github.com/lestrrat/go-server-starter/listener.ListenAll(0x0, 0x0, 0x0, 0x0, 0x0)
    /Users/nagata-hiroaki/src/github.com/lestrrat/go-server-starter/listener/listener.go:144 +0x8a
main.main()
    /Users/nagata-hiroaki/junk/2015/05/20150508_200547_server_starter/main.go:12 +0x27

goroutine 2 [runnable]:
runtime.forcegchelper()
    /usr/local/Cellar/go/1.4.2/libexec/src/runtime/proc.go:90
runtime.goexit()
    /usr/local/Cellar/go/1.4.2/libexec/src/runtime/asm_amd64.s:2232 +0x1

goroutine 3 [runnable]:
runtime.bgsweep()
    /usr/local/Cellar/go/1.4.2/libexec/src/runtime/mgc0.go:82
runtime.goexit()
    /usr/local/Cellar/go/1.4.2/libexec/src/runtime/asm_amd64.s:2232 +0x1

goroutine 4 [runnable]:
runtime.runfinq()
    /usr/local/Cellar/go/1.4.2/libexec/src/runtime/malloc.go:712
runtime.goexit()
    /usr/local/Cellar/go/1.4.2/libexec/src/runtime/asm_amd64.s:2232 +0x1
exit status 2
```

This Pull Request fix it.
