### PR TITLE
Avoid duplication boot when pid file exist

### DIFF
--- a/cmd/start_server/start_server.go
+++ b/cmd/start_server/start_server.go
@@ -148,7 +148,7 @@ func _main() (st int) {
 	}
 
 	if opts.OptPidFile != "" && fileExist(opts.OptPidFile) {
-		fmt.Print("already boot?")
+		fmt.Print("pid file exists. already boot?")
 		return
 	}
 

--- a/cmd/start_server/start_server.go
+++ b/cmd/start_server/start_server.go
@@ -147,6 +147,11 @@ func _main() (st int) {
 		os.Setenv("ENVDIR", opts.OptEnvdir)
 	}
 
+	if opts.OptPidFile != "" && fileExist(opts.OptPidFile) {
+		fmt.Print("already boot?")
+		return
+	}
+
 	s, err := starter.NewStarter(opts)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %s\n", err)
@@ -155,4 +160,9 @@ func _main() (st int) {
 	s.Run()
 	st = 0
 	return
+}
+
+func fileExist(path string) bool {
+	_, err := os.Stat(path)
+	return !os.IsNotExist(err)
 }

--- a/cmd/start_server/start_server_test.go
+++ b/cmd/start_server/start_server_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+//
+func TestShouldNotStartDuplicate(t *testing.T) {
+	dir, err := ioutil.TempDir("", fmt.Sprintf("start-server-test-%d", os.Getpid()))
+	if err != nil {
+		t.Errorf("Failed to create temp directory: %s", err)
+		return
+	}
+	defer os.RemoveAll(dir)
+
+	pidFile := filepath.Join(dir, "start_server.pid")
+	f, err := os.OpenFile(pidFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	if err != nil {
+		t.Fatal("Failed to create pid file")
+	}
+	io.WriteString(f, "1111")
+	f.Close()
+
+	exeFile := filepath.Join(dir, "start_server")
+	exec.Command("go", "build", "-o", exeFile).Run()
+
+	stdout := new(bytes.Buffer)
+	cmd := exec.Command(exeFile, "--pid-file="+pidFile, "hoge")
+	cmd.Stdout = stdout
+	cmd.Run()
+
+	if !fileExist(pidFile) {
+		t.Error("Missing pid file")
+	}
+	if stdout.String() != "pid file exists. already boot?" {
+		t.Error("Find other error")
+	}
+}


### PR DESCRIPTION
Please following topics.

## Missing pid file when duplicate call start_server
```
start_server --pid-file=start_server.pid -- hoge
start_server --pid-file=start_server.pid -- hoge
ls start_server.pid 
ls: start_server.pid: No such file or directory
```

## My product call command as described below on  hot deploy
```/bin/cat start_server.pid | xargs kill -HUP```

For that reason, it should exist pid file.
The modified so that it does not start &  not erase pid file.

Best regards.
