### PR TITLE
Feature request: signal name normalization

### DIFF
--- a/cmd/start_server/start_server.go
+++ b/cmd/start_server/start_server.go
@@ -20,7 +20,7 @@ type options struct {
 	OptInterval            int      `long:"interval" arg:"seconds" description:"minimum interval (in seconds) to respawn the server program (default: 1)"`
 	OptPorts               []string `long:"port" arg:"(port|host:port)" description:"TCP port to listen to (if omitted, will not bind to any ports)"`
 	OptPaths               []string `long:"path" arg:"path" description:"path at where to listen using unix socket (optional)"`
-	OptSignalOnHUP         string   `long:"signal-on-hup" arg:"Signal" description:"name of the signal to be sent to the server process when start_server\nreceives a SIGHUP (default: HUP). If you use this option, be sure to\nalso use '--signal-on-term' below."`
+	OptSignalOnHUP         string   `long:"signal-on-hup" arg:"Signal" description:"name of the signal to be sent to the server process when start_server\nreceives a SIGHUP (default: TERM). If you use this option, be sure to\nalso use '--signal-on-term' below."`
 	OptSignalOnTERM        string   `long:"signal-on-term" arg:"Signal" description:"name of the signal to be sent to the server process when start_server\nreceives a SIGTERM (default: TERM)"`
 	OptPidFile             string   `long:"pid-file" arg:"filename" description:"if set, writes the process id of the start_server process to the file"`
 	OptStatusFile          string   `long:"status-file" arg:"filename" description:"if set, writes the status of the server process(es) to the file"`

--- a/cmd/start_server/start_server.go
+++ b/cmd/start_server/start_server.go
@@ -20,8 +20,8 @@ type options struct {
 	OptInterval            int      `long:"interval" arg:"seconds" description:"minimum interval (in seconds) to respawn the server program (default: 1)"`
 	OptPorts               []string `long:"port" arg:"(port|host:port)" description:"TCP port to listen to (if omitted, will not bind to any ports)"`
 	OptPaths               []string `long:"path" arg:"path" description:"path at where to listen using unix socket (optional)"`
-	OptSignalOnHUP         string   `long:"signal-on-hup" arg:"Signal" description:"name of the signal to be sent to the server process when start_server\nreceives a SIGHUP (default: SIGTERM). If you use this option, be sure to\nalso use '--signal-on-term' below."`
-	OptSignalOnTERM        string   `long:"signal-on-term" arg:"Signal" description:"name of the signal to be sent to the server process when start_server\nreceives a SIGTERM (default: SIGTERM)"`
+	OptSignalOnHUP         string   `long:"signal-on-hup" arg:"Signal" description:"name of the signal to be sent to the server process when start_server\nreceives a SIGHUP (default: HUP). If you use this option, be sure to\nalso use '--signal-on-term' below."`
+	OptSignalOnTERM        string   `long:"signal-on-term" arg:"Signal" description:"name of the signal to be sent to the server process when start_server\nreceives a SIGTERM (default: TERM)"`
 	OptPidFile             string   `long:"pid-file" arg:"filename" description:"if set, writes the process id of the start_server process to the file"`
 	OptStatusFile          string   `long:"status-file" arg:"filename" description:"if set, writes the status of the server process(es) to the file"`
 	OptEnvdir              string   `long:"envdir" arg:"Envdir" description:"directory that contains environment variables to the server processes.\nIt is intended for use with \"envdir\" in \"daemontools\". This can be\noverwritten by environment variable \"ENVDIR\"."`

--- a/starter.go
+++ b/starter.go
@@ -165,6 +165,8 @@ func signame(s os.Signal) string {
 	return "UNKNOWN"
 }
 
+// SigFromName returns the signal corresponding to the given signal name string.
+// If the given name string is not defined, it returns nil.
 func SigFromName(n string) os.Signal {
 	if sig, ok := niceNameToSigs[n]; ok {
 		return sig

--- a/starter.go
+++ b/starter.go
@@ -168,6 +168,11 @@ func signame(s os.Signal) string {
 // SigFromName returns the signal corresponding to the given signal name string.
 // If the given name string is not defined, it returns nil.
 func SigFromName(n string) os.Signal {
+	n = strings.ToUpper(n)
+	if strings.HasPrefix(n, "SIG") {
+		n = n[3:] // remove SIG prefix
+	}
+
 	if sig, ok := niceNameToSigs[n]; ok {
 		return sig
 	}

--- a/starter.go
+++ b/starter.go
@@ -44,7 +44,7 @@ func makeNiceSigNames() map[syscall.Signal]string {
 
 func init() {
 	niceSigNames = makeNiceSigNames()
-	niceNameToSigs := make(map[string]syscall.Signal)
+	niceNameToSigs = make(map[string]syscall.Signal)
 	for sig, name := range niceSigNames {
 		niceNameToSigs[name] = sig
 	}

--- a/starter_test.go
+++ b/starter_test.go
@@ -152,3 +152,11 @@ func TestRun(t *testing.T) {
 	}
 
 }
+
+func TestSigFromName(t *testing.T) {
+	for sig, name := range niceSigNames {
+		if got := SigFromName(name); sig != got {
+			t.Errorf("%v: wants '%v' but got '%v'", name, sig, got)
+		}
+	}
+}

--- a/starter_test.go
+++ b/starter_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -155,6 +156,17 @@ func TestRun(t *testing.T) {
 
 func TestSigFromName(t *testing.T) {
 	for sig, name := range niceSigNames {
+		if got := SigFromName(name); sig != got {
+			t.Errorf("%v: wants '%v' but got '%v'", name, sig, got)
+		}
+	}
+
+	variants := map[string]syscall.Signal{
+		"SIGTERM": syscall.SIGTERM,
+		"sigterm": syscall.SIGTERM,
+		"Hup":     syscall.SIGHUP,
+	}
+	for name, sig := range variants {
 		if got := SigFromName(name); sig != got {
 			t.Errorf("%v: wants '%v' but got '%v'", name, sig, got)
 		}


### PR DESCRIPTION
**NOTE:** The PR includes the changes for #7. I will rebase these commits if #7 is done.

This PR makes allow to pass signal name variants like "SIGTERM" or "term". The original [Server::Starter](http://search.cpan.org/~kazuho/Server-Starter-0.32/lib/Server/Starter.pm) has the same feature.
