### PR TITLE
Fix worker exiting detection

### DIFF
--- a/starter.go
+++ b/starter.go
@@ -533,7 +533,7 @@ func (s *Starter) StartWorker(sigCh chan os.Signal, ch chan processState) *os.Pr
 			}
 
 			// Check if we can find a process by its pid
-			p := existsProcess(pid)
+			p := findWorker(pid)
 			if gotSig || p != nil {
 				// No error? We were successful! Make sure we capture
 				// the program exiting

--- a/starter.go
+++ b/starter.go
@@ -517,7 +517,6 @@ func (s *Starter) StartWorker(sigCh chan os.Signal, ch chan processState) *os.Pr
 					sigs = append(sigs, sig)
 				}
 			}
-
 			// if received any signals, during the wait, we bail out
 			gotSig := false
 			if len(sigs) > 0 {
@@ -534,8 +533,10 @@ func (s *Starter) StartWorker(sigCh chan os.Signal, ch chan processState) *os.Pr
 			}
 
 			// Check if we can find a process by its pid
-			p, err := os.FindProcess(pid)
-			if gotSig || err == nil {
+			p, _ := os.FindProcess(pid)
+			var wstatus syscall.WaitStatus
+			waitpid, _ := syscall.Wait4(pid, &wstatus, syscall.WNOHANG, nil)
+			if gotSig || waitpid <= 0 {
 				// No error? We were successful! Make sure we capture
 				// the program exiting
 				go func() {

--- a/starter.go
+++ b/starter.go
@@ -533,10 +533,8 @@ func (s *Starter) StartWorker(sigCh chan os.Signal, ch chan processState) *os.Pr
 			}
 
 			// Check if we can find a process by its pid
-			p, _ := os.FindProcess(pid)
-			var wstatus syscall.WaitStatus
-			waitpid, _ := syscall.Wait4(pid, &wstatus, syscall.WNOHANG, nil)
-			if gotSig || waitpid <= 0 {
+			p := existsProcess(pid)
+			if gotSig || p != nil {
 				// No error? We were successful! Make sure we capture
 				// the program exiting
 				go func() {

--- a/starter_any.go
+++ b/starter_any.go
@@ -2,7 +2,10 @@
 
 package starter
 
-import "syscall"
+import (
+	"os"
+	"syscall"
+)
 
 func init() {
 	failureStatus = syscall.WaitStatus(255)
@@ -27,4 +30,14 @@ func addPlatformDependentNiceSigNames(v map[syscall.Signal]string) map[syscall.S
 	v[syscall.SIGXCPU] = "XCPU"
 	v[syscall.SIGXFSZ] = "GXFSZ"
 	return v
+}
+
+func existsProcess(pid int) *os.Process {
+	var wstatus syscall.WaitStatus
+	waitpid, _ := syscall.Wait4(pid, &wstatus, syscall.WNOHANG, nil)
+	if waitpid <= 0 {
+		p, _ := os.FindProcess(pid)
+		return p
+	}
+	return nil
 }

--- a/starter_any.go
+++ b/starter_any.go
@@ -32,7 +32,7 @@ func addPlatformDependentNiceSigNames(v map[syscall.Signal]string) map[syscall.S
 	return v
 }
 
-func existsProcess(pid int) *os.Process {
+func findWorker(pid int) *os.Process {
 	var wstatus syscall.WaitStatus
 	waitpid, _ := syscall.Wait4(pid, &wstatus, syscall.WNOHANG, nil)
 	if waitpid <= 0 {

--- a/starter_windows.go
+++ b/starter_windows.go
@@ -14,7 +14,7 @@ func addPlatformDependentNiceSigNames(v map[syscall.Signal]string) map[syscall.S
 	return v
 }
 
-func existsProcess(pid int) *os.Process {
+func findWorker(pid int) *os.Process {
 	p, err := os.FindProcess(pid)
 	if err != nil {
 		return p

--- a/starter_windows.go
+++ b/starter_windows.go
@@ -1,6 +1,9 @@
 package starter
 
-import "syscall"
+import (
+	"os"
+	"syscall"
+)
 
 func init() {
 	failureStatus = syscall.WaitStatus{ExitCode: 255}
@@ -9,4 +12,12 @@ func init() {
 
 func addPlatformDependentNiceSigNames(v map[syscall.Signal]string) map[syscall.Signal]string {
 	return v
+}
+
+func existsProcess(pid int) *os.Process {
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return p
+	}
+	return nil
 }


### PR DESCRIPTION
Currently start-server kills old worker even if you failed to start a new worker.

In the Unix system, it was necessary to check the state of the process using wait4 instead of FindProcess.
 
https://golang.org/pkg/os/#FindProcess

> On Unix systems, FindProcess always succeeds and returns a Process for the given pid, regardless of whether the process exists.